### PR TITLE
Keep N most recent directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,15 +8,10 @@ module.exports = function(opts, cb) {
     var baseDir = opts.baseDir
 
     var pruneToCount = function(count, dirs, cb) {
-      
+
       // count >= dirs.length means prune nothing
       if (count >= dirs.length) {
         return cb(null, null)
-      }
-
-      // count of 0 means prune everything
-      if (count === 0) {
-        count = dirs.length
       }
 
       // sort by mtime, oldest first
@@ -24,8 +19,10 @@ module.exports = function(opts, cb) {
         return a.stats.mtime.getTime() > b.stats.mtime.getTime()
       })
 
-      // trim to *count* entries
-      dirs = dirs.slice(0, count)
+      // trim all but *count* newest entries
+      if (count !== 0) {
+        dirs = dirs.slice(0, -count)
+      }
 
       // delete *count* oldest directories
       var rmFuncs = []

--- a/test/test.js
+++ b/test/test.js
@@ -124,12 +124,14 @@ describe('#dirkeeper', function() {
 
   it('should correctly prune oldest directories when needed', function(done) {
     fs.readdir(TEN_SUBDIRS, function(err, origFiles) {
-      keeper({ baseDir: TEN_SUBDIRS, count: 5 }, function(err) {
+      keeper({ baseDir: TEN_SUBDIRS, count: 3 }, function(err) {
         fs.readdir(TEN_SUBDIRS, function(err, files) {
           var dirs = filterDirs(TEN_SUBDIRS, files)
-          expect(dirs).to.have.length(5)
+          expect(dirs).to.have.length(3)
           // the earliest dir names are the oldest. see makeDirs().
-          expect(dirs).to.not.contain(['tmpfile.0', 'tmpfile.1', 'tmpfile.2', 'tmpfile.3', 'tmpfile.4'])
+          expect(dirs).to.not.contain([
+            'tmpfile.0', 'tmpfile.1', 'tmpfile.2', 'tmpfile.3', 'tmpfile.4', 'tmpfile.5', 'tmpfile.6',
+          ])
           done()
         })
       })


### PR DESCRIPTION
Dirkeeper currently [deletes the oldest `count` subdirectories](https://github.com/FrozenRidge/dirkeeper/blob/9e2808bf84d9a31d18778937bcde40e5fcc9c8b3/index.js#L30), rather than what the README documents, which is [deleting everything but the most recent `count` subdirectories](https://github.com/FrozenRidge/dirkeeper/tree/9e2808bf84d9a31d18778937bcde40e5fcc9c8b3#usage). The special-cased counts of 0 (to delete everything) and greater-than-the-number-of-subdirectories (to delete nothing) work correctly, but are inconsistent with the less-than-the-number-of-subdirectories case.

I've changed the relevant test to make the difference more obvious by keeping a `count` that's different than the number of directories that should be deleted, then changed the `dirs` array slice to delete all-but-the-newest-_n_ so it passes.